### PR TITLE
Add explanation for Device ID in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This can then be used to package the app for samsung accordingly (see the docker
      tizen install -n MoonlightNaCl.wgt -t YOUR_DEVICE_ID
      exit
      ```
-   - Replace `YOUR_TV_IP` and `YOUR_DEVICE_ID` with your TV's IP and Device ID respectively.
+   - Replace `YOUR_TV_IP` and `YOUR_DEVICE_ID` with your TV's IP and Device ID respectively, the Device ID is the last column shown in `sdb devices`, something like `UE65NU7400`.
 
 4. **(Optional) Disable Developer Mode**:
    - Revisit the `Apps` panel to turn off Developer mode and restart the TV.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,21 @@ This can then be used to package the app for samsung accordingly (see the docker
      docker run -it --rm ghcr.io/oneliberty/moonlight-tizen-nacl:samsung_nacl
      ```
 3. **Install the Application**:
-   - Connect and install via Smart Development Bridge:
+   - Connect to the TV via Smart Development Bridge, replacing `YOUR_TV_IP` with your TV's IP:
      ```
      sdb connect YOUR_TV_IP
      sdb devices
-     tizen install -n MoonlightNaCl.wgt -t YOUR_DEVICE_ID
-     exit
      ```
-   - Replace `YOUR_TV_IP` and `YOUR_DEVICE_ID` with your TV's IP and Device ID respectively, the Device ID is the last column shown in `sdb devices`, something like `UE65NU7400`.
+   - Install the app:
+     ```
+     tizen install -n MoonlightNaCl.wgt
+     ```
+     If you have multiple TVs connected, specify which TV to install by using this command instead:
+     ```
+     tizen install -n MoonlightNaCl.wgt -t YOUR_DEVICE_ID
+     ```
+     where `YOUR_DEVICE_ID` is the last column shown in `sdb devices`, something like `UE65NU7400`.
+   - `exit`
 
 4. **(Optional) Disable Developer Mode**:
    - Revisit the `Apps` panel to turn off Developer mode and restart the TV.


### PR DESCRIPTION
The installation instructions say to replace the device ID in the command `tizen install -n MoonlightNaCl.wgt -t YOUR_DEVICE_ID`, but don't provide an explanation to what the device ID is or where to find it. I found it confusing and had to guess and find out what it is by trial and error. This PR adds the explanation in hopes that others wouldn't have to do the same guesswork.